### PR TITLE
Added default parameter with empty array

### DIFF
--- a/src/__tests__/test.ts
+++ b/src/__tests__/test.ts
@@ -12,9 +12,27 @@ describe('iswitch', () => {
         },
       ]),
     ).toBe(true);
+
+    expect(iswitch('b', ['a', () => 'A'], ['b', () => 'B'], ['c', () => 'C'])).toBe('B');
+  });
+
+  it('should handle cases with multiple keys', () => {
+    expect(iswitch('a', ['x', () => false], [['a', 'b'], () => true])).toBe(true);
   });
 
   it('should return null if there are no matches', () => {
     expect(iswitch('a', ['X', () => 'A'])).toBe(undefined);
+  });
+
+  it('should handle the default there are no matches', () => {
+    expect(iswitch('a', ['X', () => 'A'], [[], () => 'default'])).toBe('default');
+  });
+
+  it('should throw if there are duplicate keys', () => {
+    expect(() => iswitch('a', ['X', () => 'A'], [['X'], () => 'default'])).toThrowError(/^Duplicate keys: X$/);
+
+    expect(() => iswitch('a', [['X', 'Y'], () => 'A'], [['X'], () => 'X'], [['Y'], () => 'Y'])).toThrowError(
+      /^Duplicate keys: X, Y$/,
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,20 @@
+export type TestCase<T, R> = [T, TestFunction<T, R>] | [T[], TestFunction<T, R>];
+export type TestFunction<T, R> = (test: T) => R;
+
+const validate = <T>(keys: T[]) => {
+  const duplicates = keys.filter((key, index) => keys.indexOf(key) !== index);
+  if (duplicates.length > 0) {
+    throw new Error(`Duplicate keys: ${duplicates.join(', ')}`);
+  }
+};
+
 export const iswitch = <T, R>(key: T, testCase: TestCase<T, R>, ...testCases: TestCase<T, R>[]): R | undefined => {
-  const handler = [testCase, ...testCases].find((tc) => tc[0] === key || (tc[0] as T[]).includes(key));
+  const allTestCases = [testCase, ...testCases];
+  validate(allTestCases.flatMap((tc) => tc[0]));
+
+  const handler = allTestCases.find(
+    (tc) => (Array.isArray(tc[0]) && (tc[0].length === 0 || tc[0].includes(key))) || tc[0] === key,
+  );
 
   return handler?.[1](key);
 };
-
-export type TestCase<T, R> = [T, TestFunction<T, R>] | [T[], TestFunction<T, R>];
-export type TestFunction<T, R> = (test: T) => R;


### PR DESCRIPTION
Mixing rest parameters and optional curry in javascript is probably not a smart idea though.

This implementation uses an empty array as `key`.